### PR TITLE
fix: validate registration passwords and add DTOs

### DIFF
--- a/src/main/java/com/bthl/healthcare/controller/AuthController.java
+++ b/src/main/java/com/bthl/healthcare/controller/AuthController.java
@@ -81,7 +81,9 @@ public class AuthController {
         logger.info("Registration attempt for username: {}", registrationDto.getUsername());
         try {
             // I validate password confirmation if provided
-            if (registrationDto.getPassword() != null && !registrationDto.getPassword().equals(registrationDto.getPassword())) {
+            if (registrationDto.getPassword() != null &&
+                registrationDto.getConfirmPassword() != null &&
+                !registrationDto.getPassword().equals(registrationDto.getConfirmPassword())) {
                 return ResponseEntity.badRequest()
                     .body(createErrorResponse("Password confirmation does not match"));
             }

--- a/src/main/java/com/bthl/healthcare/dto/PasswordChangeDto.java
+++ b/src/main/java/com/bthl/healthcare/dto/PasswordChangeDto.java
@@ -1,0 +1,44 @@
+package com.bthl.healthcare.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Data Transfer Object for changing user passwords.
+ */
+public class PasswordChangeDto {
+
+    @NotBlank(message = "Current password is required")
+    private String currentPassword;
+
+    @NotBlank(message = "New password is required")
+    private String newPassword;
+
+    private String confirmPassword;
+
+    public PasswordChangeDto() {
+    }
+
+    public String getCurrentPassword() {
+        return currentPassword;
+    }
+
+    public void setCurrentPassword(String currentPassword) {
+        this.currentPassword = currentPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+}

--- a/src/main/java/com/bthl/healthcare/dto/UserRegistrationDto.java
+++ b/src/main/java/com/bthl/healthcare/dto/UserRegistrationDto.java
@@ -1,0 +1,115 @@
+package com.bthl.healthcare.dto;
+
+import com.bthl.healthcare.model.enums.UserType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Data Transfer Object for user registration requests.
+ */
+public class UserRegistrationDto {
+
+    @NotBlank(message = "Username is required")
+    private String username;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email should be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+
+    private String confirmPassword;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String phone;
+
+    @NotNull(message = "User type is required")
+    private UserType userType;
+
+    /**
+     * Flag to indicate whether the user should be auto verified.
+     */
+    private boolean autoVerify;
+
+    public UserRegistrationDto() {
+    }
+
+    // Getters and setters
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public UserType getUserType() {
+        return userType;
+    }
+
+    public void setUserType(UserType userType) {
+        this.userType = userType;
+    }
+
+    public boolean isAutoVerify() {
+        return autoVerify;
+    }
+
+    public void setAutoVerify(boolean autoVerify) {
+        this.autoVerify = autoVerify;
+    }
+}

--- a/src/main/java/com/bthl/healthcare/dto/UserUpdateDto.java
+++ b/src/main/java/com/bthl/healthcare/dto/UserUpdateDto.java
@@ -1,0 +1,65 @@
+package com.bthl.healthcare.dto;
+
+/**
+ * Data Transfer Object for updating user profile information.
+ */
+public class UserUpdateDto {
+
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private String timezone;
+    private String locale;
+    private String profileImageUrl;
+
+    public UserUpdateDto() {
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+}


### PR DESCRIPTION
## Summary
- add missing DTOs for registration, profile updates, and password changes
- validate registration password confirmation in `AuthController`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68941c36f358832bbb7cf1ad256b1894