### PR TITLE
fix: validate password confirmation on registration

### DIFF
--- a/src/main/java/com/bthl/healthcare/controller/AuthController.java
+++ b/src/main/java/com/bthl/healthcare/controller/AuthController.java
@@ -81,7 +81,7 @@ public class AuthController {
         logger.info("Registration attempt for username: {}", registrationDto.getUsername());
         try {
             // I validate password confirmation if provided
-            if (registrationDto.getPassword() != null && !registrationDto.getPassword().equals(registrationDto.getPassword())) {
+            if (!isPasswordConfirmed(registrationDto)) {
                 return ResponseEntity.badRequest()
                     .body(createErrorResponse("Password confirmation does not match"));
             }
@@ -366,7 +366,15 @@ public class AuthController {
         }
     }
 
-    // I implement helper methods for response creation
+    // I implement helper methods for response creation and validation
+
+    /**
+     * I verify that the password and its confirmation match during registration.
+     */
+    private boolean isPasswordConfirmed(UserRegistrationDto registrationDto) {
+        return registrationDto.getPassword() != null &&
+               registrationDto.getPassword().equals(registrationDto.getConfirmPassword());
+    }
 
     /**
      * I create standardized error responses for consistent API error handling.

--- a/src/test/java/com/bthl/healthcare/controller/AuthControllerTest.java
+++ b/src/test/java/com/bthl/healthcare/controller/AuthControllerTest.java
@@ -1,0 +1,59 @@
+package com.bthl.healthcare.controller;
+
+import com.bthl.healthcare.dto.UserRegistrationDto;
+import com.bthl.healthcare.model.enums.UserType;
+import com.bthl.healthcare.security.jwt.JwtTokenProvider;
+import com.bthl.healthcare.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    void registerUser_returnsBadRequest_whenPasswordsDoNotMatch() throws Exception {
+        UserRegistrationDto dto = new UserRegistrationDto();
+        dto.setUsername("testuser");
+        dto.setEmail("test@example.com");
+        dto.setPassword("Password123!");
+        dto.setConfirmPassword("Different123!");
+        dto.setFirstName("John");
+        dto.setLastName("Doe");
+        dto.setUserType(UserType.COMPANY_USER);
+        dto.setAcceptTerms(true);
+        dto.setAcceptPrivacyPolicy(true);
+
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("Password confirmation does not match"));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure registerUser validates password against its confirmation
- centralize password confirmation logic in helper for reuse
- add test confirming 400 response when passwords mismatch

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68942f77ecac832b8aa7e56e2a7c83a2