### PR TITLE
chore: externalize credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 # Example environment configuration for BTHL-HealthCare
 DB_URL=jdbc:postgresql://localhost:5432/bthl_healthcare
-DB_USERNAME=davestj
+DB_USERNAME=devuser
 DB_PASSWORD=change_me
 JWT_SECRET=change_me
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=change_me
+EMAIL_USERNAME=change_me
+EMAIL_PASSWORD=change_me
+TEST_DB_USERNAME=sa
+TEST_DB_PASSWORD=

--- a/SETUP.md
+++ b/SETUP.md
@@ -42,8 +42,14 @@ The application loads sensitive configuration from environment variables. Copy `
 - `JWT_SECRET` – secret key used to sign JSON Web Tokens
 - `ADMIN_USERNAME` – initial Spring Security admin user
 - `ADMIN_PASSWORD` – password for the admin user
+- `EMAIL_USERNAME` – SMTP username for sending email notifications
+- `EMAIL_PASSWORD` – SMTP password for sending email notifications
+- `TEST_DB_USERNAME` – optional H2 database username for tests (defaults to `sa`)
+- `TEST_DB_PASSWORD` – optional H2 database password for tests (defaults to empty)
 
 These variables are required for both local development and production deployments.
+
+The `.env` file is intentionally excluded from version control. Use `.env.example` as a template and populate a local `.env` file with development-only values that should never be committed.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,9 @@ TODO: Integrate SonarQube quality gates and security scanning
         <springdoc.version>2.2.0</springdoc.version>
         <testcontainers.version>1.19.3</testcontainers.version>
         <jacoco.version>0.8.11</jacoco.version>
+        <db.url>${env.DB_URL}</db.url>
+        <db.username>${env.DB_USERNAME}</db.username>
+        <db.password>${env.DB_PASSWORD}</db.password>
     </properties>
 
     <dependencies>
@@ -306,9 +309,9 @@ TODO: Integrate SonarQube quality gates and security scanning
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>${flyway.version}</version>
                 <configuration>
-                    <url>${env.DB_URL}</url>
-                    <user>${env.DB_USERNAME}</user>
-                    <password>${env.DB_PASSWORD}</password>
+                    <url>${db.url}</url>
+                    <user>${db.username}</user>
+                    <password>${db.password}</password>
                     <locations>
                         <location>classpath:db/migration</location>
                     </locations>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,10 +110,10 @@ bthl:
       smtp:
         host: localhost
         port: 1025
-        username: ""
-        password: ""
-        auth: false
-        starttls: false
+        username: ${EMAIL_USERNAME:}
+        password: ${EMAIL_PASSWORD:}
+        auth: ${EMAIL_SMTP_AUTH:false}
+        starttls: ${EMAIL_SMTP_STARTTLS:false}
 
 ---
 # Development Profile
@@ -176,8 +176,8 @@ spring:
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
-    username: sa
-    password: ""
+    username: ${TEST_DB_USERNAME:sa}
+    password: ${TEST_DB_PASSWORD:}
   
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- externalize SMTP and test database credentials into environment variables
- parameterize Flyway plugin to read database credentials from env-driven Maven properties
- document required environment variables and provide example placeholders

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.0: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689437ac3910832bb9551eb372abd09e