### PR TITLE
fix: validate registration password confirmation

### DIFF
--- a/src/main/java/com/bthl/healthcare/controller/AuthController.java
+++ b/src/main/java/com/bthl/healthcare/controller/AuthController.java
@@ -81,7 +81,7 @@ public class AuthController {
         logger.info("Registration attempt for username: {}", registrationDto.getUsername());
         try {
             // I validate password confirmation if provided
-            if (!isPasswordConfirmed(registrationDto)) {
+            if (!passwordsMatch(registrationDto.getPassword(), registrationDto.getConfirmPassword())) {
                 return ResponseEntity.badRequest()
                     .body(createErrorResponse("Password confirmation does not match"));
             }
@@ -371,9 +371,8 @@ public class AuthController {
     /**
      * I verify that the password and its confirmation match during registration.
      */
-    private boolean isPasswordConfirmed(UserRegistrationDto registrationDto) {
-        return registrationDto.getPassword() != null &&
-               registrationDto.getPassword().equals(registrationDto.getConfirmPassword());
+    private boolean passwordsMatch(String password, String confirmPassword) {
+        return password != null && password.equals(confirmPassword);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure registerUser compares password and confirmPassword
- add reusable helper `passwordsMatch`

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_689437aaef68832b9d9ffe79d238206d